### PR TITLE
FEATURE: Função para criar usuários e administradores fake para testes de banco de dados

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint --config eslint.config.mjs .",
-    "start:dev": "nodemon -r ts-node/register --exec 'npm run lint && ts-node --transpile-only ./src/app.ts'"
+    "start:dev": "nodemon -r ts-node/register --exec 'npm run lint && ts-node --transpile-only ./src/app.ts",
+    "seed": "ts-node --transpile-only ./src/seeds/database.seed.ts"
   },
   "keywords": [],
   "author": "",
@@ -13,6 +14,7 @@
   "type": "commonjs",
   "description": "",
   "dependencies": {
+    "@faker-js/faker": "^9.4.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",

--- a/src/seeds/database.seed.ts
+++ b/src/seeds/database.seed.ts
@@ -1,0 +1,78 @@
+import { PostgresDataSource } from '../config/database.config';
+import { Member } from '../entities/member.entity';
+import { accountType, ageRange, gender } from '../entities/base.entity';
+import { faker } from '@faker-js/faker';
+
+async function initializeDatabase() {
+  if (!PostgresDataSource.isInitialized) {
+    await PostgresDataSource.initialize();
+    console.log('Banco de dados inicializado.');
+  }
+}
+
+function generateFakeUsers(count, defaults = {}) {
+  return Array.from({ length: count }).map(() => ({
+    accountType: faker.helpers.arrayElement(Object.values(accountType)),
+    ageRange: faker.helpers.arrayElement(Object.values(ageRange)),
+    registrationNumber: faker.string.numeric(8),
+    fullName: faker.person.fullName(),
+    gender: faker.helpers.arrayElement(Object.values(gender)),
+    cpf: faker.string.numeric(11),
+    birthDate: faker.date.birthdate({ min: 18, max: 60, mode: 'age' }),
+    email: faker.internet.email(),
+    phone: `+55 (${faker.string.numeric(2)}) ${faker.string.numeric(5)}-${faker.string.numeric(4)}`,
+    password: faker.string.alphanumeric(10),
+    ...defaults,
+  }));
+}
+
+async function hasExistingAdmins(memberRepository) {
+  const existingAdmins = await memberRepository.find({
+    where: { accountType: accountType.ADMIN },
+  });
+  return existingAdmins.length > 1;
+}
+
+async function getAdminIDs(memberRepository) {
+  const admins = await memberRepository.find({
+    where: { accountType: accountType.ADMIN },
+    select: ['id'],
+  });
+  return admins.map((admin) => admin.id);
+}
+
+async function seedDatabase() {
+  try {
+    await initializeDatabase();
+
+    const memberRepository = PostgresDataSource.getRepository(Member);
+
+    if (await hasExistingAdmins(memberRepository)) {
+      console.log('Admins já existem no banco de dados. Seed ignorado.');
+    } else {
+      console.log('Criando administradores fakes...');
+      const fakeAdmins = generateFakeUsers(5, { accountType: accountType.ADMIN });
+      const newAdmins = memberRepository.create(fakeAdmins);
+      await memberRepository.save(newAdmins);
+      console.log('Administradores fakes criados com sucesso!');
+    }
+
+    const adminIDs = await getAdminIDs(memberRepository);
+    if (adminIDs.length === 0) {
+      console.log('Nenhum administrador disponível. Membros não serão criados.');
+      return;
+    }
+
+    console.log('Criando membros fakes...');
+    const fakeMembers = generateFakeUsers(10, {
+      adminCreatorID: faker.helpers.arrayElement(adminIDs),
+    });
+    const newMembers = memberRepository.create(fakeMembers);
+    await memberRepository.save(newMembers);
+    console.log('Membros fakes criados com sucesso!');
+  } catch (error) {
+    console.error('Erro ao criar usuários fakes:', error);
+  }
+}
+
+seedDatabase().catch(console.error);

--- a/src/services/member.service.ts
+++ b/src/services/member.service.ts
@@ -43,7 +43,7 @@ export class MemberService {
       });
       return members;
     } catch (error) {
-      console.error(`Erro ao buscar membros pelo critério ${columnName}:`, error);
+      console.error('Erro ao buscar membros pelo critério %s:', columnName, error);
       throw ErrorHandler.internalServerError(`Não foi possível buscar membros pelo critério ${columnName}.`);
     }
   }


### PR DESCRIPTION
Este pull request implementa uma função de seed para a criação de usuários e administradores fake, facilitando testes de banco de dados. A funcionalidade foi construída utilizando a biblioteca Faker para gerar dados realistas como nome, CPF, email e telefone.

**Mudanças principais**:
- **Função `initializeDatabase`**: Garante que o banco de dados seja inicializado antes de qualquer operação.
- **Função `generateFakeUsers`**: Gera uma lista de usuários fake, com parâmetros configuráveis, incluindo tipo de conta, faixa etária, gênero, entre outros.
- **Função `hasExistingAdmins`**: Verifica se já existem administradores no banco de dados, para evitar duplicação.
- **Função `getAdminIDs`**: Obtém os IDs dos administradores existentes para associar membros a eles.
- **Função `seedDatabase`**: Controla o fluxo de criação dos administradores e membros fake, garantindo que não haja duplicação de administradores e que os dados sejam gerados corretamente.

**Mudanças no banco de dados**:
- Criação de registros fake de administradores (caso não existam) e membros com vínculo a administradores.

**Motivação**:
Essa implementação facilita a criação de dados de teste para o banco de dados sem a necessidade de entrada manual de informações, otimizando o processo de testes e desenvolvimento.

**Como testar**:
1. Rodar o script de seed no ambiente de desenvolvimento - `npm run seed`
2. Verificar se os administradores e membros fake foram criados corretamente no banco de dados.
3. Verificar se a verificação de duplicação de administradores está funcionando corretamente.