### PR TITLE
Fix/http-responses

### DIFF
--- a/src/services/address.service.ts
+++ b/src/services/address.service.ts
@@ -39,6 +39,11 @@ export class AddressService {
       return addresses;
     } catch (error) {
       console.error('Erro ao listar os endereços:', error);
+
+      if (error instanceof ErrorHandler && error.statusCode === 404) {
+        throw error;
+      }
+
       throw ErrorHandler.internalServerError(
         'Não foi possível listar os endereços.'
       );

--- a/src/services/department.service.ts
+++ b/src/services/department.service.ts
@@ -39,6 +39,11 @@ export class DepartmentService {
       return departments;
     } catch (error) {
       console.error('Erro ao listar os departamentos:', error);
+
+        if (error instanceof ErrorHandler && error.statusCode === 404) {
+          throw error;
+        }
+
       throw ErrorHandler.internalServerError(
         'Não foi possível listar os departamentos.'
       );

--- a/src/services/member.service.ts
+++ b/src/services/member.service.ts
@@ -39,6 +39,11 @@ export class MemberService {
       return members;
     } catch (error) {
       console.error('Erro ao listar os membros:', error);
+
+      if (error instanceof ErrorHandler && error.statusCode === 404) {
+        throw error;
+      }
+
       throw ErrorHandler.internalServerError(
         'Não foi possível listar os membros.'
       );


### PR DESCRIPTION
## Descrição  
Este PR ajusta o tratamento de erros nas funções de listagem e busca para garantir que erros 404 sejam corretamente propagados, evitando que sejam tratados como erros 500.  

### Alterações realizadas  
- Adicionada verificação para lançar erro 404 corretamente caso ocorra um `ErrorHandler` com `statusCode === 404` nas funções de listagem completa das requisições. 